### PR TITLE
add boto3 to dependencies to fix refresh token bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tap-bing-ads',
-    version="1.0.0",
+    version="1.1.0",
     description='Singer.io tap for extracting data from the Bing Ads API',
     author='Stitch',
     url='http://singer.io',
@@ -15,10 +15,11 @@ setup(
         # Seems that suds-community is now the reference for 13.0.11.1 so we can install it now with the removal of use_2to3
         # https://github.com/BingAds/BingAds-Python-SDK/pull/192
         'bingads==13.0.11.1',
-        'requests==2.20.0',
+        'requests==2.23.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',
         'backoff==1.8.0',
+        'boto3==1.27.0'
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
# Description of change
upgraded version of requests, added boto3 to setup.py

# Manual QA steps
 - run calling job in UAT (saas-etl microsoft ads export), look for "saving refresh token to SSM now" and "SSM param not saved to SSM due to error starting boto3" in logs. 
 
# Risks
 - upgraded requests version, needs to be integration tested.
 
# Rollback steps
 - revert this branch
